### PR TITLE
add_to_validates

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ApplicationRecord
   belongs_to :movie
+  validates :content, presence: true
 end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -2,4 +2,5 @@ class Movie < ApplicationRecord
   has_one_attached :movie
   # :moveはファイルの呼び名 Active Storageは裏側でBlobとAttachmentモデルを使ってMovie.movieを使えるようにしてくれる。
   has_many :comments, foreign_key: :movie_id, dependent: :destroy
+  validates :movie,:title, presence: true
 end


### PR DESCRIPTION
# What
タイトルなど何も入力していないとデータを送信できないようにする。

# Why
からの情報が保存され、マニュアルの視認性が悪くなるのを防ぐため。